### PR TITLE
Defaulting order to 1

### DIFF
--- a/Commands/stubs/json.stub
+++ b/Commands/stubs/json.stub
@@ -4,7 +4,7 @@
     "description": "",
     "keywords": [],
     "active": 1,
-    "order": 0,
+    "order": 1,
     "providers": [
         "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Providers\\$STUDLY_NAME$ServiceProvider"
     ],


### PR DESCRIPTION
Defaults `order` in `module.json` to 1 to stop any potential issues (i.e. localisation issues)
