### PR TITLE
Run a rollback instead of a reset when refreshing migrations

### DIFF
--- a/Commands/MigrateRefreshCommand.php
+++ b/Commands/MigrateRefreshCommand.php
@@ -32,7 +32,7 @@ class MigrateRefreshCommand extends Command
      */
     public function fire()
     {
-        $this->call('module:migrate-reset', [
+        $this->call('module:migrate-rollback', [
             'module' => $this->getModuleName(),
             '--database' => $this->option('database'),
             '--force' => $this->option('force'),


### PR DESCRIPTION
This is the same change as https://github.com/nWidart/modules/pull/4 that was merged in to the master branch instead of the feature/5.1 branch
